### PR TITLE
Update test to be more specific and add note

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contributing to Learn.co Curriculum
+
+We're really exited that you're about to contribute to the [open curriculum](https://learn.co/content-license) on [Learn.co](https://learn.co). If this is your first time contributing, please continue reading to learn how to make the most meaningful and useful impact possible.
+
+## Raising an Issue to Encourage a Contribution
+
+If you notice a problem with the curriculum that you believe needs improvement
+but you're unable to make the change yourself, you should raise a Github issue
+containing a clear description of the problem. Include relevant snippets of
+the content and/or screenshots if applicable. Curriculum owners regularly review
+issue lists and your issue will be prioritized and addressed as appropriate.
+
+## Submitting a Pull Request to Suggest an Improvement
+
+If you see an opportunity for improvement and can make the change yourself go
+ahead and use a typical git workflow to make it happen:
+
+* Fork this curriculum repository
+* Make the change on your fork, with descriptive commits in the standard format
+* Open a Pull Request against this repo
+
+A curriculum owner will review your change and approve or comment on it in due
+course.
+
+# Why Contribute?
+
+Curriculum on Learn is publicly and freely available under Learn's
+[Educational Content License](https://learn.co/content-license). By
+embracing an open-source contribution model, our goal is for the curriculum
+on Learn to become, in time, the best educational content the world has
+ever seen.
+
+We need help from the community of Learners to maintain and improve the
+educational content. Everything from fixing typos, to correcting
+out-dated information, to improving exposition, to adding better examples,
+to fixing tests—all contributions to making the curriculum more effective are
+welcome.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,7 @@
+#Learn.co Educational Content License
+
+Copyright (c) 2015 Flatiron School, Inc
+
+The Flatiron School, Inc. owns this Educational Content. However, the Flatiron School supports the development and availability of educational materials in the public domain. Therefore, the Flatiron School grants Users of the Flatiron Educational Content set forth in this repository certain rights to reuse, build upon and share such Educational Content subject to the terms of the Educational Content License set forth [here](http://learn.co/content-license) (http://learn.co/content-license). You must read carefully the terms and conditions contained in the Educational Content License as such terms govern access to and use of the Educational Content.  
+
+Flatiron School is willing to allow you access to and use of the Educational Content only on the condition that you accept all of the terms and conditions contained in the Educational Content License set forth [here](http://learn.co/content-license) (http://learn.co/content-license).  By accessing and/or using the Educational Content, you are agreeing to all of the terms and conditions contained in the Educational Content License.  If you do not agree to any or all of the terms of the Educational Content License, you are prohibited from accessing, reviewing or using in any way the Educational Content.

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The board follows the following format:
 4. Three rows on the board.
 5. Rows are separated by: `-----------`
 
-> Note: If you've previously built the blank tic tac toe board in a previous lab, you may want to go back and copy it in to this lab. Feel free to also re-create the board from scratch. 
+> Note: If you've built the blank tic tac toe board in a previous lab, you may want to go back and copy it in to this lab. Feel free to also re-create the board from scratch. 
 
 ### Building Dynamic Strings with Interpolation
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ The board follows the following format:
 4. Three rows on the board.
 5. Rows are separated by: `-----------`
 
+> Note: If you've previously built the blank tic tac toe board in a previous lab, you may want to go back and copy it in to this lab. Feel free to also re-create the board from scratch. 
+
 ### Building Dynamic Strings with Interpolation
 
 Don't forget that in Ruby you can interpolate data into a string using the `"#{1+1}"` interpolation syntax. For example:

--- a/spec/display_board_spec.rb
+++ b/spec/display_board_spec.rb
@@ -6,24 +6,26 @@ describe "#display_board in 'lib/display_board.rb" do
       board = [" "," "," "," "," "," "," "," "," "]
 
       output = capture_puts{ display_board(board) }
+      rows = output.split("\n")
 
-      expect(output).to include("   |   |   ")
-      expect(output).to include("-----------")
-      expect(output).to include("   |   |   ")
-      expect(output).to include("-----------")
-      expect(output).to include("   |   |   ")
+      expect(rows[0]).to eq("   |   |   ")
+      expect(rows[1]).to eq("-----------")
+      expect(rows[2]).to eq("   |   |   ")
+      expect(rows[3]).to eq("-----------")
+      expect(rows[4]).to eq("   |   |   ")
     end
 
     it 'prints a board with an X in the center position' do
       board = [" ", " ", " ", " ", "X", " ", " ", " ", " "]
 
       output = capture_puts{ display_board(board) }
+      rows = output.split("\n")
 
-      expect(output).to include("   |   |   ")
-      expect(output).to include("-----------")
-      expect(output).to include("   | X |   ")
-      expect(output).to include("-----------")
-      expect(output).to include("   |   |   ")
+      expect(rows[0]).to eq("   |   |   ")
+      expect(rows[1]).to eq("-----------")
+      expect(rows[2]).to eq("   | X |   ")
+      expect(rows[3]).to eq("-----------")
+      expect(rows[4]).to eq("   |   |   ")
 
     end
 
@@ -33,12 +35,13 @@ describe "#display_board in 'lib/display_board.rb" do
       board[0] = "O"
 
       output = capture_puts{ display_board(board) }
+      rows = output.split("\n")
 
-      expect(output).to include(" O |   |   ")
-      expect(output).to include("-----------")
-      expect(output).to include("   |   |   ")
-      expect(output).to include("-----------")
-      expect(output).to include("   |   |   ")
+      expect(rows[0]).to eq(" O |   |   ")
+      expect(rows[1]).to eq("-----------")
+      expect(rows[2]).to eq("   |   |   ")
+      expect(rows[3]).to eq("-----------")
+      expect(rows[4]).to eq("   |   |   ")
     end
 
     it 'prints a board with an X in the center and an O in the top left' do
@@ -47,83 +50,90 @@ describe "#display_board in 'lib/display_board.rb" do
       board[4] = "X"
 
       output = capture_puts{ display_board(board) }
+      rows = output.split("\n")
 
-      expect(output).to include(" O |   |   ")
-      expect(output).to include("-----------")
-      expect(output).to include("   | X |   ")
-      expect(output).to include("-----------")
-      expect(output).to include("   |   |   ")
+      expect(rows[0]).to eq(" O |   |   ")
+      expect(rows[1]).to eq("-----------")
+      expect(rows[2]).to eq("   | X |   ")
+      expect(rows[3]).to eq("-----------")
+      expect(rows[4]).to eq("   |   |   ")
     end
 
     it 'prints a board with X winning via the top row' do
       board = ["X", "X", "X", " ", " ", " ", " ", " ", " "]
 
       output = capture_puts{ display_board(board) }
+      rows = output.split("\n")
 
-      expect(output).to include(" X | X | X ")
-      expect(output).to include("-----------")
-      expect(output).to include("   |   |   ")
-      expect(output).to include("-----------")
-      expect(output).to include("   |   |   ")
+      expect(rows[0]).to eq(" X | X | X ")
+      expect(rows[1]).to eq("-----------")
+      expect(rows[2]).to eq("   |   |   ")
+      expect(rows[3]).to eq("-----------")
+      expect(rows[4]).to eq("   |   |   ")
     end
 
     it 'prints a board with O winning via the bottom row' do
       board = [" ", " ", " ", " ", " ", " ", "O", "O", "O"]
 
       output = capture_puts{ display_board(board) }
+      rows = output.split("\n")
 
-      expect(output).to include("   |   |   ")
-      expect(output).to include("-----------")
-      expect(output).to include("   |   |   ")
-      expect(output).to include("-----------")
-      expect(output).to include(" O | O | O ")
+      expect(rows[0]).to eq("   |   |   ")
+      expect(rows[1]).to eq("-----------")
+      expect(rows[2]).to eq("   |   |   ")
+      expect(rows[3]).to eq("-----------")
+      expect(rows[4]).to eq(" O | O | O ")
     end
 
     it 'prints a board with X winning in a top left to bottom right diagonal' do
       board = ["X", " ", " ", " ", "X", " ", " ", " ", "X"]
 
       output = capture_puts{ display_board(board) }
+      rows = output.split("\n")
 
-      expect(output).to include(" X |   |   ")
-      expect(output).to include("-----------")
-      expect(output).to include("   | X |   ")
-      expect(output).to include("-----------")
-      expect(output).to include("   |   | X ")
+      expect(rows[0]).to eq(" X |   |   ")
+      expect(rows[1]).to eq("-----------")
+      expect(rows[2]).to eq("   | X |   ")
+      expect(rows[3]).to eq("-----------")
+      expect(rows[4]).to eq("   |   | X ")
     end
 
     it 'prints a board with O winning in a top right to bottom left diagonal' do
       board = [" ", " ", "O", " ", "O", " ", "O", " ", " "]
 
       output = capture_puts{ display_board(board) }
+      rows = output.split("\n")
 
-      expect(output).to include("   |   | O ")
-      expect(output).to include("-----------")
-      expect(output).to include("   | O |   ")
-      expect(output).to include("-----------")
-      expect(output).to include(" O |   |   ")
+      expect(rows[0]).to eq("   |   | O ")
+      expect(rows[1]).to eq("-----------")
+      expect(rows[2]).to eq("   | O |   ")
+      expect(rows[3]).to eq("-----------")
+      expect(rows[4]).to eq(" O |   |   ")
     end
 
     it 'prints arbitrary arrangements of the board' do
       board = ["X", "X", "X", "X", "O", "O", "X", "O", "O"]
 
       output = capture_puts{ display_board(board) }
+      rows = output.split("\n")
 
-      expect(output).to include(" X | X | X ")
-      expect(output).to include("-----------")
-      expect(output).to include(" X | O | O ")
-      expect(output).to include("-----------")
-      expect(output).to include(" X | O | O ")
+      expect(rows[0]).to eq(" X | X | X ")
+      expect(rows[1]).to eq("-----------")
+      expect(rows[2]).to eq(" X | O | O ")
+      expect(rows[3]).to eq("-----------")
+      expect(rows[4]).to eq(" X | O | O ")
 
 
       board = ["X", "O", "X", "O", "X", "X", "O", "X", "O"]
 
       output = capture_puts{ display_board(board) }
+      rows = output.split("\n")
 
-      expect(output).to include(" X | O | X ")
-      expect(output).to include("-----------")
-      expect(output).to include(" O | X | X ")
-      expect(output).to include("-----------")
-      expect(output).to include(" O | X | O ")
+      expect(rows[0]).to eq(" X | O | X ")
+      expect(rows[1]).to eq("-----------")
+      expect(rows[2]).to eq(" O | X | X ")
+      expect(rows[3]).to eq("-----------")
+      expect(rows[4]).to eq(" O | X | O ")
     end
 
     it 'prints an entire board full of Xs' do
@@ -154,11 +164,11 @@ describe "#display_board in 'lib/display_board.rb" do
 
       # *** Edit the lines below ***
       # *** Uncomment the lines below ***
-      # expect(output).to include("   |   |   ")
-      # expect(output).to include("-----------")
-      # expect(output).to include("   |   |   ")
-      # expect(output).to include("-----------")
-      # expect(output).to include("   |   |   ")
+      # expect(rows[0]).to eq("   |   |   ")
+      # expect(rows[1]).to eq("-----------")
+      # expect(rows[2]).to eq("   |   |   ")
+      # expect(rows[3]).to eq("-----------")
+      # expect(rows[4]).to eq("   |   |   ")
 
       # *** Comment the line below by adding a # at the line start ***
       expect(true).to be(true)


### PR DESCRIPTION
Update tests to check each row individually. Previous tests just checked to see if output included a row anywhere in the output and did not check for specific row location. This also allowed for extra spaces before or after the row to count as passing. 

Added note that users can copy old old display board method from previous lab if they wish. 

Closes #6 closes #9 and closes #16 

@PeterBell @pletcher 
