### PR TITLE
'rows' was undefined in the bonus section

### DIFF
--- a/spec/display_board_spec.rb
+++ b/spec/display_board_spec.rb
@@ -147,8 +147,9 @@ describe "#display_board in 'lib/display_board.rb" do
       # *** Edit the line below ***
       board = [" ", " ", " ", " ", " ", " ", " ", " ", " "] # This is not correct
 
-      # Don't touch the following line.
+      # Don't touch the following lines.
       output = capture_puts{ display_board(board) } if defined?(display_board)
+      rows = output.split("\n")
 
       # Each line that starts with expect represents a row in the ouput.
       # The desired characters a row must include are provided by the String


### PR DESCRIPTION
Also, lines 34-35

```
# Leave hint for assigning the 0 index value of O
board[0] = "O"
```

and lines 49-50

```
board[0] = "O"
board[4] = "X"
```

seem duplicative of the `board` variable assignment that immediately precedes each pair
